### PR TITLE
missing comma was preventing parsing of json file

### DIFF
--- a/codemeta.json
+++ b/codemeta.json
@@ -15,7 +15,7 @@
       "email": "tom.hengl@isric.org",
       "name": "Tomislav Hengl",
       "affiliation": "ISRIC - World Soil Information, P.O. Box 353, 6700 AJ Wageningen, The Netherlands"
-    }
+    },
     {
       "@id": "0000-0002-7249-3778",
       "@type": "Person",


### PR DESCRIPTION
p.s.: Great to see codemeta.json in the wild!  We now have a little R package to assist in generating these files based on your package DESCRIPTION if you want to try it out: https://github.com/codemeta/codemetar

There's a few minor changes to the schema but overall this is very nice!